### PR TITLE
FEAT: 반응형 UI 레이아웃 수정 및 모바일 검색 시 와인 등록 버튼 뜨도록 추가

### DIFF
--- a/src/app/wines/PageClient.tsx
+++ b/src/app/wines/PageClient.tsx
@@ -25,6 +25,7 @@ export default function PageClient({
   const router = useRouter();
   const modal = useQuickModal();
   const [search, setSearch] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [priceRange, setPriceRange] = useState<[number, number]>([0, 400000]);
   const [rating, setRating] = useState<string>("");
@@ -76,6 +77,8 @@ export default function PageClient({
             onChange={setSearch}
             onSearch={(val) => console.log("검색 실행:", val)}
             onClear={() => setSearch("")}
+            onFocus={() => setIsSearching(true)}
+            onBlur={() => setIsSearching(false)}
           />
         </div>
         <div className={styles.btn}>
@@ -174,16 +177,18 @@ export default function PageClient({
         </div>
       </div>
       {/* 모바일 전용 하단 고정 버튼 */}
-      <div className={styles.mobileBtnBottom}>
-        <Button
-          variant="primary"
-          ariaLabel="와인 등록하기"
-          className={styles.mobileRegisterBtn}
-          onClick={() => modal.add()}
-        >
-          와인 등록하기
-        </Button>
-      </div>
+      {isSearching && (
+        <div className={styles.mobileBtnBottom}>
+          <Button
+            variant="primary"
+            ariaLabel="와인 등록하기"
+            className={styles.mobileRegisterBtn}
+            onClick={() => modal.add()}
+          >
+            와인 등록하기
+          </Button>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/wines/page.module.css
+++ b/src/app/wines/page.module.css
@@ -196,7 +196,7 @@
 
   .topBar {
     display: flex;
-    width: 100%;
+    width: 114rem;
     align-items: center;
     justify-content: center;
   }

--- a/src/components/SearchInput/SearchInput.module.css
+++ b/src/components/SearchInput/SearchInput.module.css
@@ -8,29 +8,29 @@
   --search-gray-medium: var(--grayscale-300);
   --search-gray-dark: var(--grayscale-500);
   --search-gray-darker: var(--grayscale-800);
-  
+
   /* Local Spacing Variables */
   --search-spacing-xs: 0.4rem;
   --search-spacing-sm: 0.8rem;
   --search-spacing-md: var(--small);
-  
+
   /* Font Variables from Global */
   --search-font-sm: var(--md-size);
   --search-font-md: var(--lg-size);
-  
+
   /* Border Radius from Global */
   --search-radius: var(--small);
   --search-radius-sm: var(--xm-size);
-  
+
   /* Local Effect Variables */
   --search-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   --search-transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  
+
   /* Container Styles */
   position: relative;
   display: flex;
   align-items: center;
-  width: 40rem;
+  width: 100%;
   height: 4.8rem;
   background-color: var(--search-white);
   border: 0.1rem solid var(--search-gray-medium);
@@ -143,25 +143,25 @@
 /* 테블릿 (768px ~ 1023px) */
 @media (min-width: 768px) and (max-width: 1023px) {
   .container {
-    width: 32rem;
+    width: 100%;
     height: 5.2rem;
   }
-  
+
   .input {
     font-size: 1.5rem;
     padding: 1.2rem 1rem;
   }
-  
+
   .searchIcon {
     padding: 1.2rem;
   }
-  
+
   .clearButton {
     width: 3.6rem;
     height: 3.6rem;
     margin: 0.8rem;
   }
-  
+
   .container.focused {
     box-shadow: 0 0 0 0.4rem rgba(106, 67, 219, 0.1), var(--search-shadow-sm);
   }
@@ -170,33 +170,32 @@
 /* 데스크탑 (1024px ~) */
 @media (min-width: 1024px) {
   .container {
-    width: 44rem;
+    width: 70rem;
     height: 5.6rem;
   }
-  
+
   .input {
     font-size: 1.6rem;
     padding: 1.6rem 1.2rem;
   }
-  
+
   .searchIcon {
     padding: 1.6rem;
   }
-  
+
   .clearButton {
     width: 4rem;
     height: 4rem;
     margin: 1rem;
   }
-  
+
   .container.focused {
     box-shadow: 0 0 0 0.4rem rgba(106, 67, 219, 0.12), var(--search-shadow-sm);
   }
-  
+
   .searchIcon:focus-visible,
   .clearButton:focus-visible {
     outline-width: 0.3rem;
     outline-offset: 0.3rem;
   }
 }
-

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,17 +1,19 @@
-'use client';
+"use client";
 
-import { useState, useRef, KeyboardEvent, ChangeEvent } from 'react';
-import { SearchInputProps } from '../../types/component-types';
-import styles from './SearchInput.module.css';
+import { useState, useRef, KeyboardEvent, ChangeEvent } from "react";
+import { SearchInputProps } from "../../types/component-types";
+import styles from "./SearchInput.module.css";
 
-export const SearchInput = ({ 
-  value, 
-  onChange, 
-  placeholder = "와인을 검색해 보세요", 
+export const SearchInput = ({
+  value,
+  onChange,
+  placeholder = "와인을 검색해 보세요",
   onSearch,
   onClear,
   disabled = false,
-  maxLength = 100
+  maxLength = 100,
+  onFocus,
+  onBlur,
 }: SearchInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -23,13 +25,13 @@ export const SearchInput = ({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (disabled) return;
-    
-    if (e.key === 'Enter' && onSearch) {
+
+    if (e.key === "Enter" && onSearch) {
       e.preventDefault();
       onSearch(value);
     }
-    
-    if (e.key === 'Escape') {
+
+    if (e.key === "Escape") {
       inputRef.current?.blur();
       if (value && onClear) {
         onClear();
@@ -48,10 +50,21 @@ export const SearchInput = ({
     inputRef.current?.focus();
   };
 
+  const handleFocus = () => {
+    setIsFocused(true);
+    onFocus?.();
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    onBlur?.();
+  };
 
   return (
-    <div 
-      className={`${styles.container} ${isFocused ? styles.focused : ''} ${disabled ? styles.disabled : ''}`}
+    <div
+      className={`${styles.container} ${isFocused ? styles.focused : ""} ${
+        disabled ? styles.disabled : ""
+      }`}
     >
       <button
         type="button"
@@ -85,8 +98,8 @@ export const SearchInput = ({
         value={value}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         placeholder={placeholder}
         disabled={disabled}
         maxLength={maxLength}

--- a/src/types/component-types.ts
+++ b/src/types/component-types.ts
@@ -63,6 +63,8 @@ export interface SearchInputProps {
   onClear?: () => void;
   disabled?: boolean;
   maxLength?: number;
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 // Modal 컴포넌트 타입 정의
@@ -119,7 +121,10 @@ export interface WineFormModalProps {
 }
 
 // 리뷰 관련 타입
-export type ReviewFormData = Omit<components["schemas"]["CreateReviewBody"], "wineId">;
+export type ReviewFormData = Omit<
+  components["schemas"]["CreateReviewBody"],
+  "wineId"
+>;
 
 export interface ReviewFormModalProps {
   mode: "create" | "edit";


### PR DESCRIPTION
## PR 유형
- [X] 새기능 추가
- [ ] 버그수정
- [X] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타수정, 탭 사이즈 변경, 변수명 변경등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 브리핑
- 반응형 UI 레이아웃 수정 및 모바일 검색 시 와인 등록 버튼 뜨도록 추가

## 스크린샷
**- 모바일.ver 검색창에 포커스 전**  
<img width="252" height="537" alt="image" src="https://github.com/user-attachments/assets/2b6369eb-0503-439f-b31c-a5c91841cd3c" />

**- 모바일.ver 검색창에 포커스 후 => 와인 등록 버튼 생성**  
<img width="251" height="546" alt="image" src="https://github.com/user-attachments/assets/f8a94ee0-ee8d-484f-a3c6-0a8e15d618c0" />


