### PR TITLE
FEAT: 가격 슬라이더 값 겹침 개선 및 등록된 와인의 최대 가격을 기준으로 max 값 설정

### DIFF
--- a/src/app/wines/PageClient.tsx
+++ b/src/app/wines/PageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./page.module.css";
 import WineCarousel from "./Components/WineCarousel/WineCarousel";
@@ -27,9 +27,18 @@ export default function PageClient({
   const [search, setSearch] = useState("");
   const [isSearching, setIsSearching] = useState(false);
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
-  const [priceRange, setPriceRange] = useState<[number, number]>([0, 400000]);
   const [rating, setRating] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 와인 가격 중 최대값
+  const maxPrice = useMemo(() => {
+    const validPrices = wines
+      .map((w) => w.price)
+      .filter((p): p is number => typeof p === "number" && !isNaN(p));
+    return validPrices.length > 0 ? Math.max(...validPrices) : 0;
+  }, [wines]);
+
+  const [priceRange, setPriceRange] = useState<[number, number]>([0, maxPrice]);
 
   // 검색/필터링 로직
   const filteredWines = wines.filter((wine) => {
@@ -137,8 +146,8 @@ export default function PageClient({
             <RangeSlider
               type="range"
               min={0}
-              max={400000}
-              step={1000}
+              max={maxPrice}
+              step={10000}
               value={priceRange}
               onChange={setPriceRange}
               showValue

--- a/src/components/RangeSlider/RangeSlider.module.css
+++ b/src/components/RangeSlider/RangeSlider.module.css
@@ -18,6 +18,10 @@
   white-space: nowrap;
 }
 
+.bubbleAbove {
+  top: -5rem;
+}
+
 .thumb {
   -webkit-appearance: none;
   appearance: none;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -50,7 +50,12 @@ export default function RangeSlider(props: Props) {
       <div className={styles.track} style={trackStyle}>
         {props.showValue && (
           <>
-            <div className={styles.bubble} style={{ left: `${pct(minVal)}%` }}>
+            <div
+              className={`${styles.bubble} ${
+                Math.abs(maxVal - minVal) < step * 10 ? styles.bubbleAbove : ""
+              }`}
+              style={{ left: `${pct(minVal)}%` }}
+            >
               {formatKRW(minVal)}
             </div>
             <div className={styles.bubble} style={{ left: `${pct(maxVal)}%` }}>


### PR DESCRIPTION
## PR 유형
- [X] 새기능 추가
- [X] 버그수정
- [X] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타수정, 탭 사이즈 변경, 변수명 변경등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 브리핑
- 가격 슬라이더 값이 겹칠 경우, 라벨이 위쪽으로 표시되도록 UI 개선

- wines 배열에서 등록된 와인의 최대 가격을 계산하여 슬라이더 max 값에 반영

## 스크린샷
**가격 슬라이더 값 겹침 문제 해결**
<img width="408" height="193" alt="image" src="https://github.com/user-attachments/assets/1fbc7199-6dc5-4686-954e-ff63ce1a44ce" />

**등록된 와인 중 최대 가격 값을 가격 범위의 max으로 반영**
<img width="457" height="182" alt="image" src="https://github.com/user-attachments/assets/71ac7f90-0283-4e16-b8a5-2b7d98854d84" />

 
